### PR TITLE
DP-2616: Full screen mode

### DIFF
--- a/packages/react-scripts/template/public/index.html
+++ b/packages/react-scripts/template/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   </head>
-  <body>
+  <body class="dp-Body">
     <div id="root"></div>
   </body>
 </html>

--- a/packages/react-scripts/template/public/index.html
+++ b/packages/react-scripts/template/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   </head>
-  <body class="dp-Body">
+  <body>
     <div id="root"></div>
   </body>
 </html>

--- a/packages/react-scripts/template/src/App.js
+++ b/packages/react-scripts/template/src/App.js
@@ -15,6 +15,12 @@ import './styles.css';
 class App extends React.Component {
   static propTypes = {
     dpapp: PropTypes.object.isRequired,
+    uiProps: PropTypes.shape({
+      state: PropTypes.oneOf(['ready', 'loading', 'error', 'inactive']),
+      display: PropTypes.oneOf(['collapsed', 'expanded', 'fullscreen']),
+      badgeCount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      badgeVisibility: PropTypes.oneOf(['hidden', 'visible']),
+    }).isRequired,
   };
 
   state = {

--- a/packages/react-scripts/template/src/index.js
+++ b/packages/react-scripts/template/src/index.js
@@ -19,7 +19,15 @@ import * as phrasePacks from './locales/**/*.{json,yaml,yml}';
 createApp(dpapp => props => {
   ReactDOM.render(
     <DefaultDeskproApp dpapp={dpapp} phrasePacks={phrasePacks} {...props}>
-      <App dpapp={dpapp} />
+      <App
+        dpapp={dpapp}
+        uiProps={{
+          state: props.state,
+          display: props.display,
+          badgeCount: props.badgeCount,
+          badgeVisibility: props.badgeVisibility,
+        }}
+      />
     </DefaultDeskproApp>,
     document.getElementById('root')
   );


### PR DESCRIPTION
here we pass some ui properties to the the app so the userland code can react when the display changes to fullscreen and back.

since we're doing this for display,  i added some other ui props that might come in-handy in the future
when the apps upgrade to the latest sdk, their `index.html` should be updated according to the template in `packages/react-scripts/template/public/index.html`